### PR TITLE
feat: adiciona configuração padrão do RestClient

### DIFF
--- a/backend/src/main/java/com/borathings/borapagar/config/RestClientConfig.java
+++ b/backend/src/main/java/com/borathings/borapagar/config/RestClientConfig.java
@@ -1,0 +1,31 @@
+package com.borathings.borapagar.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.web.client.OAuth2ClientHttpRequestInterceptor;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Value("sigaa.api-key")
+    private String apiKey;
+
+    @Bean
+    public RestClient restClient(OAuth2AuthorizedClientManager authorizedClientManager) {
+        OAuth2ClientHttpRequestInterceptor requestInterceptor =
+                new OAuth2ClientHttpRequestInterceptor(authorizedClientManager);
+
+        return RestClient.builder()
+                .baseUrl("https://api.info.ufrn.br")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("X-API-KEY", apiKey)
+                .requestInterceptor(requestInterceptor)
+                .build();
+    }
+}


### PR DESCRIPTION
**Por favor, informe se a PR segue os requisitos obrigatórios:**

- [X] Mesmo padrão de código do projeto
- [ ] Arquivos alterados/adicionados seguem o padrão _Camel Case_
- [ ] A PR está relacionada a uma ou mais issue
- [ ] Relacionei todas as issues na seção de "Development" da PR
- [X] O código foi revisado uma vez ou mais

**Motivação para a criação da PR**
Toda requisição para o SIGAA exige a api key como header, essa PR adiciona uma configuração padrão de RestClient para lidar com isso

**O que foi feito**
- Criado configuração do RestClient para consumir API do SIGAA

